### PR TITLE
Fix typos and grammar

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,15 +2,15 @@ MetaPict
 ========
 
 A graphics library for producing beautiful pictures using Racket.
-MetaPict programs mimick the MetaPost/TikZ style known in LaTeX-circles.
+MetaPict programs mimic the MetaPost/TikZ style known in LaTeX circles.
 
 The documentation is available here:
 
-    http://soegaard.github.io/docs/metapict/metapict.html
+    https://soegaard.github.io/docs/metapict/metapict.html
 
 Please report any errors - including grammatical and spelling errors.
 
-I'd like to have a collection of user contributed examples, so consider
+I'd like to have a collection of user-contributed examples, so consider
 sharing any MetaPict programs you write.
 
 Installation

--- a/metapict/scribblings/bez.scrbl
+++ b/metapict/scribblings/bez.scrbl
@@ -15,7 +15,7 @@ A Bezier curve from point @racket[A] to point @racket[B] with
 control points @racket[A+] and @racket[B-] is represented as
 an instance of a @racket[bez] structure: @racket[(bez A A+ B- B)].
 
-Graphically such a curve begins at point @racket[A] and ends in point @racket[B].
+Graphically such a curve begins at point @racket[A] and ends at point @racket[B].
 The curve leaves point @racket[A] directed towards 
 the control point @racket[A+]. The direction in which the curve enters the
 end point @racket[B] is from @racket[B-]. 
@@ -25,7 +25,7 @@ of the Bezier curve. The points @racket[A+] and @racket[B-] are refererred
 to as control points. The point @racket[A+] is the post control of @racket[A]
 and the point @racket[B-] is the pre control of @racket[B].
 
-Most users will not have reason to work with @racket[bez] structures directly.
+Most users will not have a reason to work with @racket[bez] structures directly.
 The @racket[curve] constructor is intended to cover all use cases.
 
 Each point on the Bezier curve corresponds to a real number @math{t} between 0 and 1.
@@ -60,7 +60,7 @@ De Casteljau's algorithm is used to compute the point.}
 Returns @racket[#t] if the defining points of the two Bezier curves 
 are within pairwise distance @racket[ε] of each other.
 The default value of @math{ε=0.0001} was chosen
-to mimick the precision of MetaPost.}
+to mimic the precision of MetaPost.}
 @interaction[#:eval eval 
                     (bez~ (bez (pt 0     0) (pt 0 1) (pt 3 2) (pt 5 0))
                           (bez (pt 0.00005 0) (pt 0 1) (pt 3 2) (pt 5 0)))]
@@ -92,7 +92,7 @@ and the graphs of @math{b_1} and @math{b_2} gives the graph of @racket[b].}
             (color "blue" (draw b2)))))]
 
 @defproc[(bez-subpath [b bez?] [t0 real?] [t1 real?]) bez?]{
-Given a Bezier curve @racket[b] return a new Bezier curve @racket[c], 
+Given a Bezier curve @racket[b], return a new Bezier curve @racket[c], 
 such that @math{c(0)=b(t_0)} and @math{c(1)=b(t_1)} and
 such that the graph of @racket[c] is a subset of the graph of @racket[b].}
 @interaction[#:eval eval
@@ -103,7 +103,7 @@ such that the graph of @racket[c] is a subset of the graph of @racket[b].}
     (penwidth 4 
       (beside (draw b) 
               (color c (draw (bez-subpath b t (+ t 1/4))))))))]
-Note: The example shows that the parameterization is not an arc-length (aka unit-speed) 
+Note: The example shows that the parameterization is not an arc length (aka unit-speed) 
 parameterization.
 
 @defproc[(bez-intersection-point [b1 bez?] [b2 bez?]) (or pt? #f)]{
@@ -121,10 +121,10 @@ then @racket[#f] is returned.}
     (draw b1 b2 (color "red" (penwidth 8 (draw p))) b3))]
 
 @defproc[(bez-intersection-times [b1 bez?] [b2 bez?]) (values real? real?)]{
-If the graphs of the Bezier curves intersect numbers @math{t_1} and @math{t_2}
+If the graphs of the Bezier curves intersect, numbers @math{t_1} and @math{t_2}
 such that @math{b_1(t_1)=b_2(t_2)} are returned. If there are more than one
 intersection, the parameter values for the first intersection is returned.
-If no such numbers exist the result is @racket[(values #f #f)]. }
+If no such numbers exist, the result is @racket[(values #f #f)]. }
 @interaction[#:eval eval
   (def b1 (bez (pt 0 0) (pt 1 1) (pt 2 2) (pt 3 3)))
   (def b2 (bez (pt 0 3) (pt 1 2) (pt 2 1) (pt 3 0)))
@@ -141,8 +141,8 @@ If no such numbers exist the result is @racket[(values #f #f)]. }
 If the graphs of the Bezier curves intersect, returns a list of
 the intersection point and two numbers @math{t_1} and @math{t_2} 
 such that  @math{b_1(t_1)=b_2(t_2)}.
-If there are more than one intersection, the parameter values for the first 
-intersection is returned. If no such numbers exist the result is @racket[(values #f #f)]. }
+If there is more than one intersection, the parameter values for the first 
+intersection is returned. If no such numbers exist, the result is @racket[(values #f #f)]. }
 @interaction[#:eval eval
   (def b1 (bez (pt 0. 0.) (pt 1. 1.) (pt 2. 2.) (pt 3. 3.)))
   (def b2 (bez (pt 0. 3.) (pt 1. 2.) (pt 2. 1.) (pt 3. 0.)))
@@ -173,7 +173,7 @@ If the optional transformation @racket[t] is present, it is applied
 to @racket[b] before the conversion.}
 
 @defproc[(bezs->dc-path [bs (listof bez?)] [t trans? #f]) (is-a? dc<%>)]{
-Convert the "consecutive" Bezier curves @racket[bs] into a @racket[dc-path%].
+Convert the ``consecutive'' Bezier curves @racket[bs] into a @racket[dc-path%].
 If the optional transformation @racket[t] is present, it is applied 
 to the @racket[bs] before the conversion.}
 
@@ -183,7 +183,7 @@ to the @racket[bs] before the conversion.}
 Returns a @racket[bez] structure representing a Bezier curve from @racket[p0] to @racket[p3] 
 that leaves @racket[p0] in the direction of @racket[w0]
 and arrives in @racket[p3] from the the direction of @racket[w0] 
-with tensions @racket[t0] and @racket[t3] respectively.}
+with tensions @racket[t0] and @racket[t3], respectively.}
 @interaction[#:eval eval 
                     (defv (p0 p3 w0 w3 τ0 τ3) (values (pt 0 0) (pt 5 0) (vec 0 1) (vec 0 -1) 1 1))
                     (def b (bez/dirs+tensions p0 p3 w0 w3 τ0 τ3))
@@ -196,7 +196,7 @@ with tensions @racket[t0] and @racket[t3] respectively.}
 Returns a @racket[bez] structure representing a Bezier curve from @racket[p0] to @racket[p3] 
 that leaves @racket[p0] with an angle of @racket[θ]
 and arrives in @racket[p3] with an angle of @racket[φ] 
-with tensions @racket[t0] and @racket[t3] respectively.}
+with tensions @racket[t0] and @racket[t3], respectively.}
 @interaction[#:eval eval 
                     (defv (p0 p3 θ φ τ0 τ3) (values (pt 0 0) (pt 5 0) pi/2 -pi/2 1 1))
                     (defv (p1 p2) (control-points p0 p3 θ φ τ0 τ3))

--- a/metapict/scribblings/colors.scrbl
+++ b/metapict/scribblings/colors.scrbl
@@ -19,11 +19,11 @@ Given a color name as a string, @racket[make-color*] returns a @racket[color%] o
 
 Given real numbers to use as the color components, @racket[make-color*] works
 like @racket[make-color], but accepts both non-integer numbers, and 
-numbers outside the range 0--255. For a real number @racket[x] the value
+numbers outside the range 0--255. For a real number @racket[x], the value
 used is @racket[(min 255 (max 0 (exact-floor x)))].
 
 The optional argument @racket[α] is the transparency. The default value is 1.
-Given a transparency outside the interval 0--1 whichever value of 0 and 1 is
+Given a transparency outside the interval 0--1, whichever value of 0 and 1 is
 closest to @racket[α] is used.}
 @interaction-eval[#:eval eval (set-curve-pict-size 50 50)] 
 @interaction[#:eval eval 
@@ -40,7 +40,7 @@ closest to @racket[α] is used.}
 In an expression context @racket[(color c p)] is equivalent to @racket[(colorize p c)]
 and @racket[(color f c p)] is equivalent to @racket[(colorize p (color* f c))].
 
-As a match pattern @racket[(color r g b a)] matches both @racket[color%] objects 
+As a match pattern, @racket[(color r g b a)] matches both @racket[color%] objects 
 and color names (represented as strings). The variables @racket[r], 
 @racket[g], and, @racket[b] will be bound to the red, green, and, blue components
 of the color. The variable @racket[a] will be bound to the transparency.}
@@ -62,7 +62,7 @@ The color can be a @racket[color%] object or a color name (string).}
 
 @defproc[(color+ [c1 color] [c2 color]) (is-a?/c color%)]{
 Returns a @racket[color%] object, whose color components are
-the components of @racket[c1] and @racket[c2] added componentwise.
+the components of @racket[c1] and @racket[c2] added component-wise.
 The transparency is @racket[(min 1.0 (+ α1 α2))] where 
 @racket[α1] and @racket[α2] the transparencies of the two colors.}
 
@@ -72,7 +72,7 @@ The transparency is @racket[(min 1.0 (+ α1 α2))] where
 
 @defproc[(color* [k real?] [c color]) (is-a?/c color%)]{
 Returns a @racket[color%] object, whose color components are the 
-components of @racket[c] multiplied componentwise with @racket[k].
+components of @racket[c] multiplied component-wise with @racket[k].
 The transparency is the same as in @racket[c].}
 
 @interaction-eval[#:eval eval (set-curve-pict-size 50 50)] 
@@ -81,8 +81,8 @@ The transparency is the same as in @racket[c].}
 
 @defproc[(color-med [t real?] [c1 color] [c2 color]) (is-a?/c color%)]{
 Interpolates linearly between the colors @racket[c1] and @racket[c2].
-For @math["t=0"] the color @racket[c1] is returned, and when 
-@math["t=1"] the color @racket[c2] is returned.}
+For @math["t=0"], the color @racket[c1] is returned, and when 
+@math["t=1"], the color @racket[c2] is returned.}
 
 @interaction-eval[#:eval eval (set-curve-pict-size 50 50)] 
 @interaction[#:eval eval (with-window (window 0 1 0 1)
@@ -92,7 +92,9 @@ For @math["t=0"] the color @racket[c1] is returned, and when
 
 @defproc[(color-med* [t real?] [cs (listof color)]) (is-a?/c color%)]{
 Interpolates linearly between the colors in the list @racket[cs].
-For @math{"t=0"} corresponds to the first color in the list,
+@; The previous "For" doesn't seem to make sense. I'd just remove it, but
+@; that would make the sentence start with "t=0", which looks odd.
+The value @math{"t=0"} corresponds to the first color in the list,
 and @math{"t=1"} corresponds to the last color.}
 
 @interaction-eval[#:eval eval (set-curve-pict-size 50 50)]

--- a/metapict/scribblings/coordinates.scrbl
+++ b/metapict/scribblings/coordinates.scrbl
@@ -76,13 +76,13 @@ Let us connect the point @math{p2} with @math{p5} and @math{p3} with @math{p4}.
 If you zoom, you will see that the lines have a thickness and
 that the ends are rounded. Imagine that you have a pen with
 a circular nib. The drawings produced by MetaPict will try
-to mimick the result you get by drawing with such a pen.
+to mimic the result you get by drawing with such a pen.
 In the chapter on pens you will learn to the control the 
 thickness of the pen and the shape of the ends of lines.
 
 @section[#:tag "displacements"]{Displacements}
 
-In the example above the point @math{p2=(100,100)} was described as being 100 to 
+In the example above, the point @math{p2=(100,100)} was described as being 100 to 
 the right and 100 upwards relative to the reference point (0,0).
 
 An alternative way of describing the location of @math{p2} would be to say

--- a/metapict/scribblings/curve.scrbl
+++ b/metapict/scribblings/curve.scrbl
@@ -14,7 +14,6 @@
 @; ----------------------------------------
 
 General curves are drawn by gluing together a series of Bezier curves.
-Conceptually a curve consists of multiple Bezier curves glued together.
 Such a curve can be either open or closed (a loop).
 
 The representation of a curve consists simply of a list of Bezier curves
@@ -27,7 +26,7 @@ The actual representation uses a @racket[curve:] structure.
 The reflection name of @racket[curve:] is @racket['curve], so the names is printed without
 the colon suffix.}
 
-Most users will not have reason to work with @racket[curve:] structures directly.
+Most users will not have a reason to work with @racket[curve:] structures directly.
 The @racket[curve] constructor is intended to cover all use cases. The constructor
 can be used to construct both curved as well as straight lines.
 
@@ -87,12 +86,12 @@ parameterize the curve.
 @interaction[#:eval eval
   (curve-length (curve p0 .. p1 .. p2 .. p3 .. p4))]}
 
-Given a curve @racket[c] one can compute points on the curve corresponding to a parameter value
+Given a curve @racket[c], one can compute points on the curve corresponding to a parameter value
 between 0 and the curve length with the function @racket[point-of].
 @defproc[(point-of [c curve?] [t real?]) pt?]{
 Given a curve @racket[c] and a number @racket[t] the function @racket[point-of]
 computes the point corresponding to the parameter value @racket[t].
-Here @racket[(point-of c 0)] and @racket[(point-of c (curve-length c))] will
+Here, @racket[(point-of c 0)] and @racket[(point-of c (curve-length c))] will
 return the start and and end point of the curve respectively.
 @interaction[#:eval eval
   (let ()
@@ -107,7 +106,7 @@ return the start and and end point of the curve respectively.
       (draw c
             (label-parameter-values))))]}
 
-Since the start and end point of a curve are used often, the following short hands are available:
+Since the start and end point of a curve are used often, the following shorthands are available:
 
 @defproc[(start-point [c curve?]) pt?]{
 Returns the start point of a curve.}
@@ -125,9 +124,9 @@ a start point to an end point, one can use @racket[curve-reverse]
 to create a curve where the parameterization is reversed.
 
 @defproc[(curve-reverse [c curve?]) curve?]{
-Returns a curve throught the same points as the curve @racket[c].
-In the parameterization 0 corresponds to the end point of @racket[c]
-and @racket[(curve-length c)] corresponds to start point og @racket[c].
+Returns a curve through the same points as the curve @racket[c].
+In the parameterization, 0 corresponds to the end point of @racket[c]
+and @racket[(curve-length c)] corresponds to the start point of @racket[c].
 @interaction[#:eval eval
   (let ()
     (def c (curve (pt 0 0) .. (pt 1 3) .. (pt 2 5)))
@@ -158,7 +157,7 @@ we will look at is intersections between two curves.
 @defproc[(intersection-times [c1 curve?] [c2 curve?]) (or #f number?)]{
 If the two curves @racket[c1] and @racket[c2] have an intersection point,
 the function will return times (parameter values) @math{t} and @math{u} such that
-@math{c1(t)=c2(u)}. If no intersection point is found @racket[#f] is returned.
+@math{c1(t)=c2(u)}. If no intersection point is found, @racket[#f] is returned.
 @interaction[#:eval eval
   (let ()
     (def c1 (curve (pt 0 0) .. (pt 2 3)))
@@ -205,7 +204,7 @@ If a curve is too long, the function @racket[subcurve] can be used to
 make a shorter one.
 
 @defproc[(subcurve [c curve?] [t0 number?] [t1 number?]) curve?]{
-Produces a curve from @math{c(t_0)} to @math{c(t_1)}. If @math{t_0<t_1}
+Produces a curve from @math{c(t_0)} to @math{c(t_1)}. If @math{t_0<t_1},
 the direction is reversed.
 @interaction[#:eval eval
   (let ()
@@ -218,7 +217,7 @@ the direction is reversed.
 Instead of @racket[subcurve] one can use @racket[cut-before] and @racket[cut-after]
 to make curves shorter.
 @defproc[(cut-before [c1 curve?] [c2 curve?]) curve?]{
-Cut the part of @racket[c1] that lie before the "first" intersection point of
+Cut the part of @racket[c1] that lies before the ``first'' intersection point of
 the two curves.
 @interaction[#:eval eval
   (let ()
@@ -232,7 +231,7 @@ the two curves.
 
 
 @defproc[(cut-after [c1 curve?] [c2 curve?]) curve?]{
-Cut the part of @racket[c1] that lie after the "first" intersection point of
+Cut the part of @racket[c1] that lies after the ``first'' intersection point of
 the two curves.
 @interaction[#:eval eval
   (let ()
@@ -246,16 +245,16 @@ the two curves.
 
 @defproc[(post-control [c curve?] [t number?]) pt?]{
 The curve @racket[c] consists of a number of Bezier curves.
-Return the first control point after the paramter value @racket[t].
+Return the first control point after the parameter value @racket[t].
 See the MetaFontBook page 134.}
 
 @defproc[(pre-control [c curve?] [t number?]) pt?]{
 The curve @racket[c] consists of a number of Bezier curves.
-Return the first control point before the paramter value @racket[t].
+Return the first control point before the parameter value @racket[t].
 See the MetaFontBook page 134.}
 
 @defproc[(direction-of [c curve?] [t number?]) vec?]{
-Return the direction of which the curve @racket[c] is moving at time @racket[t].
+Return the direction in which the curve @racket[c] is moving at time @racket[t].
 @interaction[#:eval eval
   (let ()
     (def c (curve (pt 1 0) .. (pt 1 3) .. (pt 4 1)))
@@ -267,7 +266,7 @@ Return the direction of which the curve @racket[c] is moving at time @racket[t].
             (dot-label-top "P" p))))]}
 
 @defproc[(cyclic? [c curve?]) boolean?]{
-Return the true value @racket[#t] if the curve @racket[c] is a closed curve.
+Return @racket[#t] if the curve @racket[c] is a closed curve.
 @interaction[#:eval eval
   (let ()
     (def c1 (curve (pt 1 0) .. (pt 1 3)))
@@ -277,8 +276,8 @@ Return the true value @racket[#t] if the curve @racket[c] is a closed curve.
 
 @defproc[(intercurve [α number?] [c1 curve?] [c2 curve?]) curve?]{
 Given two curves @racket[c1] and @racket[c2] of the same length,
-the call @racket[(intercurve α c1 c2)] will return a curve "between"
-the two curves. For @racket[α=0] the first curve is return and
+the call @racket[(intercurve α c1 c2)] will return a curve ``between''
+the two curves. For @racket[α=0] the first curve is returned and
 for @racket[α=1] the second curve is returned.
 
 In other words we can interpolate curves.
@@ -307,11 +306,11 @@ In other words we can interpolate curves.
     
 
 @defproc[(curve [<path-specification-fragment <path-specification-fragment] ...) curve:?]{
-The overall purpose of @racket[curve] is to find a "nice" (possibly closed) curve
-through a given set of points. If the user wants, he can specify how the curve
-enters and leave a point.
+The overall purpose of @racket[curve] is to find a ``nice'' (possibly closed) curve
+through a given set of points. If the user wants, they can specify how the curve
+enters and leaves a point.
 
-Concretely @racket[curve] converts a path specification into a list of bezier curves.
+Concretely, @racket[curve] converts a path specification into a list of bezier curves.
 In the most basic form, a call to @racket[curve] has one of these forms (but see
 @emph{path operations} for more options):
 
@@ -322,7 +321,7 @@ In the most basic form, a call to @racket[curve] has one of these forms (but see
 Here @racket[p0], @racket[p1], ... are points and @racket[j0], @racket[j0], ...
 are @emph{path joins}. A path join describes how the two points on either
 side of the path join are to be connected. The most common path joins are 
-@racket[..], and  @racket[--].
+@racket[..] and  @racket[--].
 
 @interaction[#:eval eval
   (defv (A B C D) (values (pt -0.3 -0.3) (pt 0.3 -0.3) (pt 0.3 0.3) (pt -0.3 0.3)))
@@ -335,13 +334,13 @@ side of the path join are to be connected. The most common path joins are
 
 The function @racket[curve] is a smart constructor, so it accepts a wider range
 of inputs and rewrites the given path specification into a basic one as the
-step of computing the list of Bezier curves. In particular you can optionally use
-direction specifiers before and/or after a point, to control the direction the
+step of computing the list of Bezier curves. In particular, you can use
+direction specifiers before and/or after a point, to control the direction in which the
 curve will enter and leave a point.
 
 @centered[@racket[...  j- ds- p ds+ j+ ...]]
 
-Here the @racket[-] and @racket[+] indicates "before" and "after" the point.
+Here the @racket[-] and @racket[+] indicates ``before'' and ``after'' the point.
 
 Finally @racket[curve] supports @emph{path operations}. A path operation @racket[f]
 can be placed after a point @racket[p]:
@@ -355,7 +354,7 @@ the path operation (a function) @racket[f] will be called with
 where @racket[f] has been removed.
 
 A few path operations such as @racket[/-], @racket[-/], @racket[--++], 
-@racket[-arc], @racket[-rectangle] are builtin. A user can define his
+@racket[-arc], @racket[-rectangle] are builtin. A user can define their
 own path operations.
 
 Given two points and a path join (and some extra pieces of information), @racket[curve]
@@ -367,7 +366,7 @@ The standard path joins are @racket[..] and  @racket[--].
 @deftogether[
   (@defthing[.. tension-and? #:value (tension-and 1 1)]
    @defthing[-- full-join? #:value (full-join (curl 1) .. (curl 1))])]{
-     Use @racket[..] to get "medium bendiness" and @racket[--] to get a straight line.}
+     Use @racket[..] to get ``medium bendiness'' and @racket[--] to get a straight line.}
 
 @defthing[cycle 'cycle]{
 The value used to indicate a closed curve is @racket['cycle].}
@@ -382,15 +381,15 @@ The value used to indicate a closed curve is @racket['cycle].}
 These path joins represent the most basic joins. They are not meant to be used
 directly (although @racket[controls-and] are occasionally useful), but are used internally.}
 
-The "tension" controls how "stiff/bendable" the curve is.
+The ``tension'' controls how ``stiff/bendable'' the curve is.
 
 The tension numbers @racket[τ-] and @racket[τ+] are real numbers.
 If a tension τ is positive, that tension is used.
-If a tension τ is negative, it is interpreted as "at least abs(τ)".
-The default tension is 1. A tension of ∞ gives a (almost) linear curve.
+If a tension τ is negative, it is interpreted as ``at least abs(τ)''.
+The default tension is 1. A tension of ∞ gives an (almost) linear curve.
 
 Note: @racket[(tension τ)] will return @racket[(tension-and τ τ)],
-this represent the same tension before and after a point.
+this represents the same tension before and after a point.
 
 
 @interaction[#:eval eval
@@ -405,8 +404,8 @@ this represent the same tension before and after a point.
            (draw (curve A ..  B (tension 10)    C) points))))]
 
 
-The path join @racket[controls-and] explicitly give the Bezier control points between the two points.
-This can be used, if a piece of a curve has been computed elsewhere.
+The path join @racket[controls-and] explicitly gives the Bezier control points between the two points.
+This can be used if a piece of a curve has been computed elsewhere.
 
 @interaction[#:eval eval
   (defv (A B C D) (values (pt -0.3 -0.3) (pt -0.3 0.0) (pt 0.3 0.3) (pt 0.6 0.3)))
@@ -417,17 +416,16 @@ This can be used, if a piece of a curve has been computed elsewhere.
 
 The last basic path join is @racket[(full-join ds- j ds+)] which allows
 one to specify an direction @racket[ds-] for the curve to enter the point and
-an direction @racket[ds+] to leave the points as well as the tension.
+a direction @racket[ds+] to leave the points as well as the tension.
 
 A @emph{direction specifier} can either be empty (represented by @racket[#f]),
-an explicit direction (an @racket[vec?]) or an curl amount.
+an explicit direction (a @racket[vec?]) or a curl amount.
 
 @defstruct*[curl ([amount real?])]{
 Warning: Currently @racket[curl] doesn't behave exactly like MetaPost (due to a bug 
 in Metapict).}
 
-Note that @racket[curve] will a join with direction specifiers before and after a 
-join into a full-fjoin.
+A join with direction specifiers before and after turns into a @racket[full-join].
 
 As an example 
 

--- a/metapict/scribblings/device.scrbl
+++ b/metapict/scribblings/device.scrbl
@@ -16,7 +16,7 @@
 @deftogether[(
   @defparam[curve-pict-width  width  real? #:value 100]
   @defparam[curve-pict-height height real? #:value 100])]{
-Parameters use to determine the size of the pict created, when
+Parameters used to determine the size of the pict created, when
 a curve is converted into a pict by @racket[draw] or similar.
 
 The size is in device coordinates.
@@ -29,15 +29,15 @@ Sets the parameters @racket[curve-pict-width] and @racket[curve-pict-width]
 to @racket[w] and @racket[h] or to the width and height of the pict @racket[p].}
 
 @defparam[curve-pict-window win window? #:value (window -1.1 1.1 -1.1 1.1)]{
-Parameter that holds the currrent logical coordinate system in use.
-The coordinates of points and vectors using the logical coordinate system.
-When drawn the logical coordinate system is mapped into device coordinates.
+Parameter that holds the current logical coordinate system in use.
+The coordinates of points and vectors use the logical coordinate system.
+When drawn, the logical coordinate system is mapped to device coordinates.
 
-For most purposes, it is practical to keep the aspect ration of the
-logical window the same as ratio between device aspect ratio.}
+For most purposes, it is practical to keep the aspect ratio of the
+logical window the same as the device aspect ratio.}
 
 @defproc[(trans-logical-to-device [win window] [device-width real?] [device-height real?]) trans?]{
-Computes the affine trandformation from the logical coordinate system given by the
+Computes the affine transformation from the logical coordinate system given by the
 window @racket[win] to the window given by @racket[(window 0 device-width 0 device-height)].
 }
 
@@ -48,7 +48,7 @@ Computes the transformation from the current window to device coordinates.}
   @defproc[(px  [a real?]) real?]
   @defproc[(xpx [a real?]) real?]
   @defproc[(ypx [a real?]) real?])]{
-Computes the size of an pixel in logical units.}
+Computes the size of a pixel in logical units.}
 
 
 

--- a/metapict/scribblings/draw-and-fill.scrbl
+++ b/metapict/scribblings/draw-and-fill.scrbl
@@ -16,7 +16,7 @@
 
 A @racket[curve] represents the path of a curve. Use @racket[draw]
 and @racket[fill] to create a picture in the form of a @racket[pict].
-Given a single curve @racket[draw] will use the current pen to
+Given a single curve, @racket[draw] will use the current pen to
 stroke the path and @racket[fill] will use the current brush to fill it.
 
 The size of the pict created by draw and fill functions is determined 
@@ -31,11 +31,11 @@ will be drawn.
 @defproc[(draw [d drawable?] ...) pict?]{
 Creates a pict representing an image of the drawable arguments.
 
-Given no arguments a blank pict will be returned.
+Given no arguments, a blank pict will be returned.
 
-Given multiple arguments @racket[draw] will convert each argument
+Given multiple arguments, @racket[draw] will convert each argument
 into a pict, then layer the results using @racket[cc-superimpose].
-In other words: it draw the arguments in order, starting with the first. 
+In other words: it draws the arguments in order, starting with the first. 
 
 This table shows how the drawable objects are converted:
 @(table
@@ -53,6 +53,7 @@ This table shows how the drawable objects are converted:
          (label-bot "Origo" (pt 0 0)))]
 
 @defproc[(draw* [ds list?]) pict?]{
+@; This sentence is hard to understand.
 Draw using @racket[draw] the non-false values in the list @racket[ds] 
 on the same pict.
 @interaction[#:eval eval 
@@ -72,13 +73,14 @@ The inside is drawn with the brush and the outside is left untouched.
 For a simple non-intersecting curve it is simple to decide
 whether a point is on the inside or outside. For self-intersecting
 curves the so-called winding rule is used. The winding rule is
-also used when filling multiple curves
+also used when filling multiple curves.
 
-Given a point P consider a ray from P towards infinity. For each
+Given a point P, consider a ray from P towards infinity. For each
 intersection between the ray and the curve(s), determine whether
 the curve crosses right-to-left or left-to-right. Each right-to-left
-crossing counts as +1 and each left-to-right crossing as -1. If
-the total sum of the counts are non-zero, then then point will be
+crossing counts as +1 and each left-to-right crossing as -1.
+@; Use clearer sentence, as discussed on Slack.
+If the total sum of the counts are non-zero, then the point will be
 filled.}
 
 Let's look at four concentric circles.
@@ -93,7 +95,7 @@ For a single curve, the orientation doesn't affect the filling:
 @interaction[#:eval eval 
      (beside (fill c1) (fill r1))]
 For the first filled circle, the winding sum is +1, and
-for the second it is -1. Since they are non-zero both
+for the second it is -1. Since they are non-zero, both
 circles are filled.
 
 The four combinations for two circles are:

--- a/metapict/scribblings/examples.scrbl
+++ b/metapict/scribblings/examples.scrbl
@@ -198,8 +198,8 @@ The inspiration was Florian Lesaint's
 
 @;void[#<<IGNORE
 @section[#:tag "example-rgb-triangle" #:style png-picts]{RGB Triangle}
-This examples shows how linear gradients can be used to fill a triangle.
-The first example use gradients from one color to another along the
+This example shows how linear gradients can be used to fill a triangle.
+The first example uses gradients from one color to another along the
 edge of a triangle. The second example shows how @emph{fading} from a color 
 @racket[c] to @racket[(change-alpha c 0)] is done.
 

--- a/metapict/scribblings/labels.scrbl
+++ b/metapict/scribblings/labels.scrbl
@@ -83,6 +83,6 @@ Useful for debugging label placements.}
 
 @defproc[(fill-label [fill-color color?] [l label?]) pict?]{
 Fill the bounding box of the label with the fill color, then draw the label.
-Useful to remove "background noise" below a label.
+Useful to remove ``background noise'' below a label.
 }
 

--- a/metapict/scribblings/pict.scrbl
+++ b/metapict/scribblings/pict.scrbl
@@ -17,7 +17,7 @@
 All images in MetaPict are represented as @racket[pict]s. A @racket[pict]
 is a structure that holds information on how to draw a picture. 
 A @racket[pict] can be @emph{rendered} to produce an image in various
-formats such as png, pdf, and, svg. 
+formats such as PNG, PDF, and SVG. 
 
 The standard library @racket[pict] defines several functions to
 construct and manipulate @racket[pict]s. MetaPict provides and
@@ -30,9 +30,9 @@ for, say, @racket[circle] to return a curve. In the @racket[pict] library
 the name @tt{circle} returns a @racket[pict], so to avoid a name conflict
 it is exported as @racket[circle-pict].
 
-An attempt have been made to make the @racket[pict] the last argument
+An attempt has been made to make the @racket[pict] the last argument
 of all operations. This explains the existance of a few functions whose
-functionality overlap with the @racket[pict] library.
+functionalities overlap with the @racket[pict] library.
 
 The operations in this section operate on @racket[pict]s, so use
 @racket[draw] to convert curves into @racket[pict]s.
@@ -126,11 +126,11 @@ Use the pen @racket[a-pen] as the current pen, then draw the pict @racket[p].}
   (pen teacher-pen (draw unitcircle))]
 
 @defproc[(dashed [p pict?]) pict]{
-Use the pen style @racket['long-dash] to draw the pict @racket[p]}
+Use the pen style @racket['long-dash] to draw the pict @racket[p].}
 @interaction[#:eval eval (dashed (draw unitcircle))]
 
 @defproc[(dotted [p pict?]) pict]{
-Use the pen style @racket['dot] to draw the pict @racket[p]}
+Use the pen style @racket['dot] to draw the pict @racket[p].}
 @interaction[#:eval eval (dotted (draw unitcircle))]
 
 @subsection[#:tag "ref-pict-brush-adjusters"]{Brush Adjusters}
@@ -178,7 +178,8 @@ Use a gradient as brush, then draw the pict @racket[p].}
 
 @defproc[(save-pict [filename path?] [p pict?] [type 'png]) (void)]{
 Save the pict @racket[p] as @racket[filename].}
-Default is png, other formats include svg, pdf, xbm, xpm and bmp.
+The default format is @racket['png], other formats include @racket['svg],
+@racket['pdf], @racket['xbm], @racket['xpm] and @racket['bmp].
 JPEG is not included.
 
 @defproc[(margin [r real?] [p pict?]) pict?]{
@@ -209,7 +210,7 @@ Same as @racket[(apply vc-append ps)]}
 
 @defproc[(beside* [ps list?]) pict?]{
 Draw the picts in the list @racket[ps] beside each other.
-The first element is on the left If the picts are of different heights, center them.
+The first element is on the left. If the picts are of different heights, center them.
 
 Same as @racket[(apply hc-append ps)]}
 

--- a/metapict/scribblings/representation.scrbl
+++ b/metapict/scribblings/representation.scrbl
@@ -13,7 +13,7 @@
 
 This section describes the representation of the MetaPict concepts.
 The structures have already been described in this manual. The intent
-is to give an overview of the data structures used in a single place.
+is to give an overview of the data structures in a single place.
 
 @defstruct[pt ([x real?] [y real?])]{
 The @racket[pt] structure represents a point with coordinates

--- a/metapict/scribblings/trans.scrbl
+++ b/metapict/scribblings/trans.scrbl
@@ -194,15 +194,15 @@ The transformation @racket[(trans 1 0 0 1 a b)]. @linebreak[]
 The transformation @racket[(trans a b -b a 0 0)]. @linebreak[]
 @centered{@math{(x,y)} zscaled a b = @math{(ax-ay,bx+ay)}}
 
-Note:  (1,0) zscaled (a,b) = (a,b) , thus (1,0) is rotated and 
-scaled into (a,b). Think of zscaled as "complex multiplaction".
+Note: (1,0) zscaled (a,b) = (a,b) , thus (1,0) is rotated and 
+scaled into (a,b). Think of zscaled as ``complex multiplaction''.
 
-In the example the red curve is multiplied with @math{0+1i}, which
+In the example, the red curve is multiplied with @math{0+1i}, which
 corresponds to a rotation of 90 degrees.
 
-In the example the blue curve is multiplied with @math{1+1i}, which
-corresponds to a rotation of 45 degrees. Also the since the
-magnitude of @math{1+1i} is @math{sqrt(2)} the figure is scaled with
+In the example, the blue curve is multiplied with @math{1+1i}, which
+corresponds to a rotation of 45 degrees. Also, since the
+magnitude of @math{1+1i} is @math{sqrt(2)}, the figure is scaled by
 the factor @math{sqrt(2)}.
 
 @interaction[#:eval eval
@@ -221,7 +221,7 @@ the factor @math{sqrt(2)}.
 @defproc[(rotated [θ real?]) 
          trans?]{
 The transformation @racket[(rotated theta)] is a rotation of θ 
-radian around @math{(0,0)}.
+radians around @math{(0,0)}.
 
 @interaction[#:eval eval
   (def c ; a heart shaped curve
@@ -255,7 +255,7 @@ degrees around @math{(0,0)}.
 @defproc[(rotated-about [θ real?] [p pt?]) 
          trans?]{
 The transformation @racket[(rotated-about θ)] is a rotation of θ 
-radian around the point @math{p}.
+radians around the point @math{p}.
 
 @interaction[#:eval eval
   (def c ; a heart shaped curve


### PR DESCRIPTION
- Fix obvious typos
- Fixed commas (hopefully actual fixes; I'm no grammar expert ;-) )
- Fixed a few seemingly wrong or hard to comprehend sentences to what I
  think they mean (partly after discussion with Jens Axel on Slack). In
  some cases I've added Scribble comments (`@; ...`).
- Changed "regular quotes" to ``typographic'' quotes

I also changed the file `curves.scrbl` because I thought it was included
in the actual documentation, but the included file seems to be just a
similar one.