### PR TITLE
Fixed reflection

### DIFF
--- a/metapict/trans.rkt
+++ b/metapict/trans.rkt
@@ -132,12 +132,13 @@
 (define (reflected p q . args) ; reflect around the line through p and q
   (def pq (pt- q p))
   (defm (vec x y) pq)
-  (def θ  (acos (/ x (sqrt (+ (sqr x) (sqr y))))))
-  (apply ((shifted x y)
+  (defm (pt u v) p)
+  (def θ  (atan y x)) ; use atan to take the different quadrants into account
+  (apply ((shifted u v) ; shift by one of the points on the line
           (rotated θ)
           reflecty
           (rotated (- θ))
-          (shifted (- x) (- y)))
+          (shifted (- u) (- v)))
          args))
 
 (define (det T) 


### PR DESCRIPTION
First of all: Keep up the good work! Metapict is a very nice project!

I used Metapict create graphics for a talk about vector calculations and found some problems regarding the reflection. I realized that `reflected` only reflects around the origin and further that the reflection depends on the order of the points `p` and `q` (sometimes the reflection was along the line and not perpendicular as it should). Therefore I forked the repo and performed the following changes in `reflected`:

* Substituted `acos` by `atan` to take different quadrants into account appropriately.
* Substituted the shift coordinates `x`, `y` (which are only relative coordinates) by absolute coordinates of one of the points (`p`) on the line (now `u` and `v`).

Since I am a Racket n00b, please review carefully. :smile_cat: 