### PR TITLE
deps: add data-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,6 +2,7 @@
 (define collection 'multi)
 (define version    "0.1")
 (define deps '("base"
+               "data-lib"
                "draw-lib"
                "math-lib"
                "gui-lib"


### PR DESCRIPTION
https://github.com/soegaard/metapict/commit/2eeef8b27dea09d5e1e317f06b4b8b8318cbe5e2 updated the collection info.rkt, which doesn't specify deps (the _package_ info.rkt does): fix the package spec to resolve a build error in the default mode of newer Racket versions that check dependencies.