### PR TITLE
Include metapict in 'GUI and Graphics Libraries' section of manual

### DIFF
--- a/metapict/info.rkt
+++ b/metapict/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 
-(define scribblings '(("scribblings/metapict.scrbl" ())))
+(define scribblings '(("scribblings/metapict.scrbl"  () (gui-library))))
 (define compile-omit-paths 
   '("todo"     ; this contains unfinished bits and pieces
     "exp"      ; experiments written to see how stuff works


### PR DESCRIPTION
Include metapict in 'GUI and Graphics Libraries' section of manual

https://docs.racket-lang.org/index.html#:~:text=GUI%20and%20Graphics%20Libraries